### PR TITLE
Update requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,7 @@
   version: 1.0.0
 
 - name: swapfile
-  src: tersmitten.swapfile
+  src: oefenweb.swapfile
   version: v2.0.6
 
 - name: fail2ban


### PR DESCRIPTION
It seems that tersmitten changed the owner of the repo (or his username in github) to Oefenweb. Currently requirement install fails because ansible can't find tersmitten.swapfile. It works properly after change I propose.